### PR TITLE
Adding a new file on Lead Ads under the Channel configuration

### DIFF
--- a/docs/documentation/channelConfiguration/fb-lead-ads.md
+++ b/docs/documentation/channelConfiguration/fb-lead-ads.md
@@ -1,0 +1,70 @@
+---
+title: Facebook Lead Ads Configuration
+sidebar_label: FB Lead Ads
+---
+
+## Facebook Lead ads
+
+On Facebook, the brands can roll out forms for generating interest and leads among the Facebook users (or potential customers).
+
+### Pre-filled forms
+
+The major problem with respect to filling forms in general is the poor form completion rate. The users abandon the form perhaps due to more no.of questions.
+
+The FB’s pre-filled forms solve this problem by pre-populating the KYC questions such as name, contact number, email ID. This way the interested usee is expected only to answer the primary requirement they have/the problem they face.
+
+This potentially increases the form completion rate.
+
+## The integration with FB’s lead ads
+
+### The process has two parts
+
+1. Requirements and form creation
+2. Lead data storage in the Yellow Messenger’s backend
+
+### Requirements and form creation
+
+1. A valid [business page](https://www.facebook.com/business/products/pages) on Facebook for the brand
+2. A link to [privacy policy](https://en-gb.facebook.com/business/help/1247534515288168?id=735435806665862) on what all info you will collect, how do you intend to use the data etc
+
+![](https://cdn.yellowmessenger.com/3Tek7aSPVPE21617813693423.png)
+
+3. A valid website URL of the brand
+
+![](https://cdn.yellowmessenger.com/zsXyiXsQ2tM31617811266955.png)
+
+4. A relevant name of the form based on the set of questions (e.g, Yellow Beauty free expert consultation)
+5. Add the actual questions the brand intends to ask
+6. A relevant description of the form
+
+![](https://cdn.yellowmessenger.com/hSO2YxYbOn8w1617813819307.png)
+
+## Lead data storage in the Yellow Messenger’s backend
+
+1. Inside the Yellow Messenger platform, navigate to Configuration → Channels
+2. Under Channels, select the ‘Facebook Lead Ads’ option
+
+![](https://cdn.yellowmessenger.com/otHQcaj1K7Qe1617814320929.png)
+
+3. Now, tap on ‘Connect with Facebook’ and login with the brand’s account login credentials
+
+![](https://cdn.yellowmessenger.com/Lmdi7Kryb5CF1617814542734.png)
+
+4. After successfully logging in, our platform gets connected with the FB account.
+5. Now, select the Facebook page associated with your brand that you want to integrate with Yellow Messenger platform.
+6. The page ID and access token gets auto-filled
+7. Select the Unique ID (UID) based on the form you created and click on ‘Connect’.
+
+![](https://cdn.yellowmessenger.com/IscS4jemLXJB1617814556215.png)
+
+8. Once successfully connected, test the flow from form submission to lead storage in YM’s backend. Go to ‘Lead Ads Testing Tool’.
+
+![](https://cdn.yellowmessenger.com/Ot6b7ANaPg1p1617814575258.png)
+
+9. Test the form submission flow by choosing the brand’s associated page and the form created already.
+
+![](https://cdn.yellowmessenger.com/g3qhlH0LZOGb1617814588764.png)
+
+10. The leads captured live get stored onto the Yellow Messenger’s backend which can be used by the brand for customer engagement.
+
+Congrats! With this, you have understood how to configure 'Facebook Lead Ads' to the Yellow Messenger platform.

--- a/sidebars.js
+++ b/sidebars.js
@@ -45,7 +45,7 @@ module.exports = {
         "howtos/basics/access-management",
         "howtos/basics/add-faqs",
         "howtos/basics/compare-code",
-        "howtos/basics/variables-in-UI"
+        "howtos/basics/variables-in-UI",
       ],
     },
     {
@@ -57,7 +57,7 @@ module.exports = {
         "howtos/create/database-management",
         "howtos/create/api-management",
         "howtos/create/localisation",
-       // "howtos/create/setup-did-you-mean",
+        // "howtos/create/setup-did-you-mean",
       ],
     },
     {
@@ -142,6 +142,7 @@ module.exports = {
         "documentation/channelConfiguration/generic-webhook",
         "documentation/channelConfiguration/fb-workplace",
         "documentation/channelConfiguration/telegram",
+        "documentation/channelConfiguration/fb-lead-ads",
       ],
     },
     {


### PR DESCRIPTION
Have added a doc on 'Facebook Lead Ads' configuration for storing the form leads in our platform DB itself. This falls under 'Engage'.